### PR TITLE
ソート順が逆になっているのを修正する

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,7 +121,7 @@ class MohiLogger(object):
 
 
 ml = MohiLogger()
-context = ml.get_channel_log(u'_checker')
+context = ml.get_channel_log(u'tsurai')
 html = ml.render_to_template(context)
 
 # テンプレートファイルへの流し込み

--- a/main.py
+++ b/main.py
@@ -86,6 +86,10 @@ class MohiLogger(object):
         """
         channel_id = self.channel_dict[channel]
         messages = self.get_channel_history(channel_id)
+
+        # `ts` を見て最新の投稿日が最後に来るようにする
+        messages.sort(key=lambda m: float(m['ts']))
+
         for message in messages:
             self.process_each_message(message)
         return {'messages': messages}
@@ -117,7 +121,7 @@ class MohiLogger(object):
 
 
 ml = MohiLogger()
-context = ml.get_channel_log(u'tsurai')
+context = ml.get_channel_log(u'_checker')
 html = ml.render_to_template(context)
 
 # テンプレートファイルへの流し込み


### PR DESCRIPTION
取得してきたデータが、最新の投稿が先頭に来る形になっている。

取得してきたデータの `ts` を見てソートをする形かしら。